### PR TITLE
fix-sign-up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :avatar])
+  end
 end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :received_reviews, through: :items, source: :reviews
   after_create :send_welcome_email
 
-  has_attachments :avatar
+  has_attachment :avatar
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:facebook]

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,7 +19,13 @@
       <!-- Avatar with dropdown menu -->
       <div class="navbar-wagon-item">
         <div class="dropdown">
-          <% avatar_url = current_user.facebook_picture_url || "avatar_demo.jpg"  %>
+          <% if current_user.facebook_picture_url %>
+            <% avatar_url = current_user.facebook_picture_url %>
+          <% elsif current_user.avatar.present? %>
+            <% avatar_url = cl_image_path(current_user.avatar.path) %>
+          <% else %>
+            <% avatar_url = "avatar_demo.jpg" %>
+          <% end %>
           <%= image_tag avatar_url, class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
 
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">


### PR DESCRIPTION
This change includes parameters besides the devise default e-mail, password and FB avatar picture  which are available when on uses FB sign in.
In the case of e-mail sign in we included first_name, last_name and avatar.
avatar was especially tricky as it requires lots of attention in the s at the end of avatar and attachments as there is just one avatar for any users, everything should be in singular.
Very important, also, was to include an if structure at the _navbar.html.erb in order to check if the current_user.facebook_picture_url is available, and will be used, otherwise, for e-mail sign in, avatar_url = cl_image_path(current_user.avatar.path will be used, else the default "avatar_demo.jpg" is used.
